### PR TITLE
Use `.env` file for scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "devnet": "anvil",
     "commitlint": "commitlint --edit",
     "deploy-local": "forge script scripts/Deploy.s.sol --rpc-url http://localhost:8545 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --broadcast",
-    "deploy-public": "forge script scripts/Deploy.s.sol --chain-id $CHAIN_ID --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast"
+    "deploy-public": "export $(cat .env | grep -v \\# | xargs) && forge script scripts/Deploy.s.sol --chain-id $CHAIN_ID --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
Small change to make it possible to use `.env` file and define the environment variables to be used by the deploy script.